### PR TITLE
Support deploying to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ npm install
 
 Run the server:
 
-```
-coffee app.coffee
+```shell
+npm start
 ```
 
 *Note*: You can use `nodemon` to watch for changes for you.

--- a/app.coffee
+++ b/app.coffee
@@ -23,8 +23,8 @@ contextBuilder = (options={}) ->
   baseContext = {urls, conditions, user}
   _.extend {}, baseContext, options
 
-port = 3000
-base = "http://127.0.0.1:#{port}"
+port = process.env.PORT or 3000
+base = process.env.BASE_URL or "http://127.0.0.1:#{port}"
 
 # Used for example purposes, see README
 todoServer = 'http://127.0.0.1:4000/api/todos'
@@ -91,4 +91,4 @@ app.post '/api/todos/:id/mark_active', (req, res) ->
 app.get '*', (req, res) ->
   res.sendFile __dirname + '/public/index.html'
 
-app.listen 3000
+app.listen port

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "Hypermedia Todo",
+  "description": "Example Hypermedia Todo Service.",
+  "repository": "https://github.com/smizell/hypermedia-todo",
+  "website": "https://github.com/smizell/hypermedia-todo",
+  "keywords": [
+    "api",
+    "siren",
+    "hypermedia"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "name": "hypermedia-todo-example",
   "version": "0.0.1",
   "description": "",
-  "main": "server1.js",
   "author": "Stephen Mizell",
   "license": "MIT",
   "dependencies": {
+    "coffee-script": "latest",
     "body-parser": "^1.9.2",
     "cors": "^2.5.1",
     "express": "^4.10.1",
     "lodash": "^2.4.1"
+  },
+  "scripts": {
+    "start": "coffee app.coffee"
   }
 }


### PR DESCRIPTION
This introduces a few tweaks such as following PORT env variable and BASE_URL to make it easier to deploy to Heroku, along with adding a missing dependency on coffee-script.

I've also introduced an [app.json](https://blog.heroku.com/archives/2014/5/22/introducing_the_app_json_application_manifest) file for Heroku for one-click deploys (like the [polls api](https://github.com/apiaryio/polls-api#deploying-on-heroku)). I haven't added a button as there is still a manual process of setting BASE_URL, which can be set like so:

``` shell
$ heroku config:set BASE_URL=$(heroku apps:info -s  | grep web_url | cut -d= -f2 | rev | cut -c 2- | rev)
```

Perhaps it would make sense to instead construct this from a request. Since the incoming request may include the `Host` used via a header.

Anyway, you can find a deployed instance at https://obscure-garden-8380.herokuapp.com.
